### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include LICENSE


### PR DESCRIPTION
Adding this MANIFEST file will include both requirements.txt and LICENSE in the sdist bundle on PyPI. Right now they are omitted. The main problem with that is as I'm trying to put this package on Conda Forge, setup.py fails because it cannot find requirements.txt in the sdist bundle it tries to build from.