### PR TITLE
Forward args from apply_and_annotate to apply_test

### DIFF
--- a/statannotations/Annotator.py
+++ b/statannotations/Annotator.py
@@ -240,10 +240,10 @@ class Annotator:
 
         return self._get_output()
 
-    def apply_and_annotate(self):
+    def apply_and_annotate(self, num_comparisons='auto', **stats_params):
         """Applies a configured statistical test and annotates the plot"""
 
-        self.apply_test()
+        self.apply_test(num_comparisons='auto', **stats_params)
         return self.annotate()
 
     def configure(self, **parameters):


### PR DESCRIPTION
so you can use the shortcut convenience `apply_and_annotate` method with parameters instead of calling `apply_test` and `annotate` individually.  
See also https://stackoverflow.com/a/72445947/3944322.