### PR TITLE
Added unit test to test labelling with floats on the x_axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ statannot.egg-info/PKG-INFO
 statannot.egg-info/requires.txt
 statannot.egg-info/SOURCES.txt
 statannot.egg-info/top_level.txt
+
+# IDE files
+.idea/

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -40,6 +40,33 @@ class TestAnnotator(unittest.TestCase):
             "hue": "color",
             "order": ["a", "b"],
             "hue_order": ['red', 'blue']}
+
+        self.df_x_float = pd.DataFrame(
+            data={
+                "x_axis": [1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02,
+                           1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01,
+                           1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03],
+                "y_axis": [16.99, 10.34, 21.01, 23.68, 24.59, 25.29, 8.77,
+                           26.88, 15.04, 14.78, 10.27, 35.26, 15.42, 18.43,
+                           14.83, 21.58, 10.33, 16.29, 16.97, 20.65, 17.92,
+                           20.29, 15.77, 39.42],
+                "hue": ["hue_2", "hue_2", "hue_1", "hue_1", "hue_2", "hue_2",
+                        "hue_2", "hue_1", "hue_2", "hue_1", "hue_1", "hue_2",
+                        "hue_1", "hue_1", "hue_0", "hue_0", "hue_2", "hue_1",
+                        "hue_0", "hue_0", "hue_2", "hue_0", "hue_2", "hue_1"]
+            }
+        )
+        self.params_float = {
+            "data": self.df_x_float,
+            "x": "x_axis",
+            "y": "y_axis",
+            "hue": "hue",
+            "hue_order": ["hue_0", "hue_1", "hue_2"],
+            "order": [1.01, 1.02, 1.03]
+        }
+        self.ax_float = sns.boxplot(**self.params_float)
+
+
         self.params_arrays = {
             "data": None,
             "x": self.df['x'],
@@ -50,6 +77,16 @@ class TestAnnotator(unittest.TestCase):
 
     def test_init_simple(self):
         self.annot = Annotator(self.ax, [(0, 1)], data=self.data)
+
+    def test_init_float(self):
+        self.annot_float = Annotator(
+            self.ax_float,
+            pairs=[
+                ((1.01, "hue_0"), (1.01, "hue_1")),
+                ((1.02, "hue_0"), (1.02, "hue_1"))
+            ],
+            **self.params_float
+        )
 
     def test_init_df(self):
         self.ax = sns.boxplot(**self.params_df)
@@ -169,6 +206,11 @@ class TestAnnotator(unittest.TestCase):
         self.test_init_simple()
         self.annot.configure(test="Mann-Whitney")
         self.annot.apply_and_annotate()
+
+    def test_support_float_labels(self):
+        self.test_init_float()
+        self.annot_float.configure(test='Mann-Whitney')
+        self.annot_float.apply_and_annotate()
 
     def test_get_annotation_text_in_input_order(self):
         self.test_init_df()


### PR DESCRIPTION
To enhance tests for float values on the x_axis (they are currently supported). Also added PyCharm IDE files to the .gitignore file to avoid accidental commit of these files. Refers to this issue: https://github.com/trevismd/statannotations/issues/65

Not sure if the test is properly coded (EDIT: second commit should make the whole thing closer to what was already in place). In case the commit is not clear, here is the code (user-oriented) to create the figure and make sure the result is the one expected that I used as inspiration to make the unit test (I checked it did not run and now runs with your latest commits):

```py
import seaborn as sns
import pandas as pd
import matplotlib.pyplot as plt
from statannotations.Annotator import Annotator

y_axis = [16.99, 10.34, 21.01, 23.68, 24.59, 25.29, 8.77, 26.88, 15.04, 14.78, 10.27, 35.26, 15.42, 18.43, 14.83, 21.58,
          10.33, 16.29, 16.97, 20.65, 17.92, 20.29, 15.77, 39.42, 19.82, 17.81, 13.37, 12.69, 21.7, 19.65, 9.55, 18.35,
          15.06, 20.69, 17.78, 24.06, 16.31, 16.93, 18.69, 31.27, 16.04, 17.46, 13.94, 9.68, 30.4, 18.29, 22.23, 32.4,
          28.55, 18.04]
x_axis = [1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03,
          1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03,
          1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02, 1.03, 1.01, 1.02]
df = pd.DataFrame(data={"y_axis": y_axis, "x_axis": x_axis})
x = "x_axis"
y = "y_axis"
order = [1.01, 1.02, 1.03]

ax = sns.boxplot(data=df, x=x, y=y, order=order)

pairs = [(1.01, 1.02), (1.02, 1.03)]

annotator = Annotator(ax, pairs, data=df, x=x, y=y, order=order)
annotator.configure(test='Mann-Whitney', text_format='star', loc='outside')
annotator.apply_and_annotate()
plt.savefig('test.png', dpi=300, bbox_inches='tight')
```