### PR TITLE
Add paired t-test greater and less than comparisons

### DIFF
--- a/statannotations/stats/StatTest.py
+++ b/statannotations/stats/StatTest.py
@@ -111,6 +111,14 @@ STATTEST_LIBRARY = {
     't-test_ind':       StatTest(stats.ttest_ind,
                                  't-test independent samples',
                                  't-test_ind', 't'),
+    
+    't-test_paired-gt':    StatTest(stats.ttest_rel,
+                                 't-test paired samples', 't-test_rel', 't',
+                                 alternative="greater"),
+
+    't-test_paired-ls':    StatTest(stats.ttest_rel,
+                                 't-test paired samples', 't-test_rel', 't',
+                                 alternative="less"),
 
     't-test_welch':     StatTest(stats.ttest_ind,
                                  'Welch\'s t-test independent samples',

--- a/statannotations/stats/test.py
+++ b/statannotations/stats/test.py
@@ -7,7 +7,8 @@ from statannotations.stats.ComparisonsCorrection import \
 from statannotations.stats.StatResult import StatResult
 from statannotations.stats.StatTest import StatTest
 
-IMPLEMENTED_TESTS = ['t-test_ind', 't-test_welch', 't-test_paired',
+IMPLEMENTED_TESTS = ['t-test_ind', 't-test_welch',
+                    't-test_paired', 't-test_paired-gt', 't-test_paired-ls',
                      'Mann-Whitney', 'Mann-Whitney-gt', 'Mann-Whitney-ls',
                      'Levene', 'Wilcoxon', 'Kruskal', 'Brunner-Munzel']
 


### PR DESCRIPTION
Add t-test_paired-gt and t-test_paired-ls to StatTest. Currently only the two-sided alternative of paired t-test is available, while e.g. Mann-Whitney provides all three.

Follows the same naming scheme and passes automated tests and manual testing.