### PR TITLE
Fix keeping annotation with reduced ylim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## v0.5
+### v0.5.1
+- Fix keeping annotation with reduced ylim (Issue [#91]
+  (https://github.com/trevismd/statannotations/issues/91))
+
 ### v0.5.0
 - Add scipy's Brunner-Munzel test
 - Fix applying statannotations for non-string group labels (Issue 

--- a/statannotations/Annotator.py
+++ b/statannotations/Annotator.py
@@ -693,7 +693,7 @@ class Annotator:
 
     def _plot_line(self, line_x, line_y):
         if self.loc == 'inside':
-            self.ax.plot(line_x, line_y, lw=self.line_width, c=self.color)
+            self.ax.plot(line_x, line_y, lw=self.line_width, c=self.color, clip_on=False)
         else:
             line = lines.Line2D(line_x, line_y, lw=self.line_width,
                                 c=self.color, transform=self.ax.transData)


### PR DESCRIPTION
The annotation lines were disappearing if the ylim was manually reduced. https://github.com/trevismd/statannotations/issues/91
The `clip_on` option was set for `loc='outside'` but not `loc='inside'`.