### PR TITLE
hide_non_significant kwarg should be configurable

### DIFF
--- a/statannotations/Annotator.py
+++ b/statannotations/Annotator.py
@@ -38,6 +38,7 @@ CONFIGURABLE_PARAMETERS = [
     'text_offset',
     'use_fixed_offset',
     'verbose',
+    'hide_non_significant'
 ]
 
 
@@ -268,6 +269,7 @@ class Annotator:
             corresponds to "{suffix}"
             * a custom formatting string using "{star}" for the original
             pvalue and '{suffix}' for 'ns'
+        * `hide_non_significant`: Hide annotations for non-significant pairs
         * `line_height`: in axes fraction coordinates
         * `line_offset`
         * `line_offset_to_group`


### PR DESCRIPTION
`hide_non_significant` optional kwarg was added to `Annotator` but wasn't made configurable. This PR aims at fixing this bug.

This worked:
```py
from statannotations.Annotator import Annotator
import matplotlib.pyplot as plt
import seaborn as sns

sns.set(style="whitegrid")

df = sns.load_dataset("tips")

x = "day"
y = "total_bill"
order = ['Sun', 'Thur', 'Fri', 'Sat']
ax = sns.boxplot(data=df, x=x, y=y, order=order)
annot = Annotator(
    ax,
    [("Thur", "Fri"), ("Thur", "Sat"), ("Fri", "Sun")],
    data=df,
    x=x,
    y=y,
    order=order,
    hide_non_significant=False
)
annot.configure(test='Mann-Whitney', text_format='star', loc='outside', verbose=2)
annot.apply_test()
ax, test_results = annot.annotate()

# show with big margins
plt.subplots_adjust(top=0.80)
plt.show()
```

This did not but should:
```py
from statannotations.Annotator import Annotator
import matplotlib.pyplot as plt
import seaborn as sns

sns.set(style="whitegrid")

df = sns.load_dataset("tips")

x = "day"
y = "total_bill"
order = ['Sun', 'Thur', 'Fri', 'Sat']
ax = sns.boxplot(data=df, x=x, y=y, order=order)
annot = Annotator(
    ax,
    [("Thur", "Fri"), ("Thur", "Sat"), ("Fri", "Sun")],
    data=df,
    x=x,
    y=y,
    order=order
)
annot.configure(test='Mann-Whitney', text_format='star', loc='outside', verbose=2, hide_non_significant=False)
annot.apply_test()
ax, test_results = annot.annotate()

# show with big margins
plt.subplots_adjust(top=0.80)
plt.show()
```

Both work after the PR.
Tests were passed on `Python 3.11.1`.

I squashed everything like suggested [last time I made a PR](https://github.com/trevismd/statannotations/pull/84).