### PR TITLE
Remove test for UserWarning

### DIFF
--- a/tests/test_stattest.py
+++ b/tests/test_stattest.py
@@ -58,6 +58,5 @@ class TestStatTest(unittest.TestCase):
     @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
     def assert_print_pvalue(self, test, zero_method, expected_output_regex,
                             mock_stdout):
-        with self.assertWarns(UserWarning):
-            test(self.x, self.y, zero_method=zero_method)
+        test(self.x, self.y, zero_method=zero_method)
         self.assertRegex(mock_stdout.getvalue(), expected_output_regex)


### PR DESCRIPTION
Fixes CI checks in #156

With scipy>=1.15.0 (due to commit https://github.com/scipy/scipy/commit/1d57f315d9454446d333d37d19f2a44f4baf35c9) no UserWarning is emitted with a Wilcoxon test with too few data. 
Testing for UserWarning was not needed anyway.