### PR TITLE
Option to capitalise "p" in p-values

### DIFF
--- a/statannotations/PValueFormat.py
+++ b/statannotations/PValueFormat.py
@@ -181,7 +181,8 @@ class PValueFormat(Formatter):
             p_letter = "P" if self.p_capitalized else "p"
 
             return ("{}{} = {}{}"
-                .format(text, p_letter, self.pvalue_format_string, result.pvalue, result.significance_suffix))
+                    .format('{}', p_letter, self.pvalue_format_string, '{}')
+                    .format(text, result.pvalue, result.significance_suffix))
 
         elif self.text_format == 'star':
             was_list = False

--- a/statannotations/PValueFormat.py
+++ b/statannotations/PValueFormat.py
@@ -12,7 +12,8 @@ CONFIGURABLE_PARAMETERS = [
     'simple_format_string',
     'text_format',
     'pvalue_thresholds',
-    'show_test_name'
+    'show_test_name',
+    'p_capitalized'
 ]
 
 
@@ -38,6 +39,7 @@ class PValueFormat(Formatter):
         self._pvalue_thresholds = self._get_pvalue_thresholds(DEFAULT)
         self._correction_format = "{star} ({suffix})"
         self.show_test_name = True
+        self.p_capitalized = False
 
     def config(self, **parameters):
 
@@ -176,9 +178,10 @@ class PValueFormat(Formatter):
             text = (f"{result.test_short_name} " if self.show_test_name
                     else "")
 
-            return ("{}p = {}{}"
-                    .format('{}', self.pvalue_format_string, '{}')
-                    .format(text, result.pvalue, result.significance_suffix))
+            p_letter = "P" if self.p_capitalized else "p"
+
+            return ("{}{} = {}{}"
+                .format(text, p_letter, self.pvalue_format_string, result.pvalue, result.significance_suffix))
 
         elif self.text_format == 'star':
             was_list = False
@@ -199,7 +202,7 @@ class PValueFormat(Formatter):
         # elif self.text_format == 'simple':
         else:
             return simple_text(result, self.simple_format_string,
-                               self.pvalue_thresholds, self.show_test_name)
+                               self.pvalue_thresholds, self.show_test_name, self.p_capitalized)
 
     def get_configuration(self):
         return {key: getattr(self, key) for key in CONFIGURABLE_PARAMETERS}

--- a/statannotations/format_annotations.py
+++ b/statannotations/format_annotations.py
@@ -33,7 +33,7 @@ def pval_annotation_text(result: List[StatResult],
 
 
 def simple_text(result: StatResult, pvalue_format, pvalue_thresholds,
-                short_test_name=True) -> str:
+                short_test_name=True, p_capitalized=False) -> str:
     """
     Generates simple text for test name and pvalue.
 
@@ -51,11 +51,13 @@ def simple_text(result: StatResult, pvalue_format, pvalue_thresholds,
             if short_test_name and result.test_short_name
             else "")
 
+    p_letter = "P" if p_capitalized else "p"
+
     for threshold in thresholds:
         if result.pvalue < threshold[0]:
-            pval_text = "p ≤ {}".format(threshold[1])
+            pval_text = "{} ≤ {}".format(p_letter, threshold[1])
             break
     else:
-        pval_text = "p = {}".format(pvalue_format).format(result.pvalue)
+        pval_text = "{} = {}".format(p_letter, pvalue_format).format(result.pvalue)
 
     return result.adjust(text + pval_text)

--- a/tests/test_pvalue_format.py
+++ b/tests/test_pvalue_format.py
@@ -114,6 +114,7 @@ class Test(unittest.TestCase):
         self.assertDictEqual(pvalue_format.get_configuration(),
                              {'correction_format': '{star} ({suffix})',
                               'fontsize': 'medium',
+                              'p_capitalized': False,
                               'pvalue_format_string': '{:.3e}',
                               'show_test_name': True,
                               'simple_format_string': '{:.2f}',
@@ -137,3 +138,10 @@ class Test(unittest.TestCase):
                                  "      ns: 5.00e-02 < p <= 1.00e+00\n"
                                  " <= 0.05: 1.00e-03 < p <= 5.00e-02\n"
                                  "<= 0.001: p <= 1.00e-03\n\n")
+        
+    def test_pvalue_capitalized(self):
+        self.annotator.configure(pvalue_format={"text_format": "simple",
+                                                "p_capitalized": True})
+        annotations = self.annotator._get_results("auto", pvalues=self.pvalues)
+        self.assertEqual(["P ≤ 0.05", "P ≤ 0.05", "P = 0.90"],
+                         [annotation.text for annotation in annotations])

--- a/tests/test_pvalue_format.py
+++ b/tests/test_pvalue_format.py
@@ -139,9 +139,18 @@ class Test(unittest.TestCase):
                                  " <= 0.05: 1.00e-03 < p <= 5.00e-02\n"
                                  "<= 0.001: p <= 1.00e-03\n\n")
         
-    def test_pvalue_capitalized(self):
+    def test_pvalue_simple_capitalized(self):
         self.annotator.configure(pvalue_format={"text_format": "simple",
                                                 "p_capitalized": True})
         annotations = self.annotator._get_results("auto", pvalues=self.pvalues)
         self.assertEqual(["P ≤ 0.05", "P ≤ 0.05", "P = 0.90"],
+                         [annotation.text for annotation in annotations])
+
+    def test_pvalue_full_capitalized(self):
+        self.annotator.configure(pvalue_format={"text_format": "full",
+                                                "p_capitalized": True,
+                                                "show_test_name": False,
+                                                "pvalue_format_string": "{:.2f}"})
+        annotations = self.annotator._get_results("auto", pvalues=self.pvalues)
+        self.assertEqual(["P = 0.04", "P = 0.03", "P = 0.90"],
                          [annotation.text for annotation in annotations])


### PR DESCRIPTION
Some journals (i.e. Nature portfolio) prefer capital "P" for p-values when preparing figures (i.e. "P = 0.027", not "p = 0.027"). 

This pull request adds p_capitalized as a parameter to PValueFormat (with default set to False to keep current behaviour) to allow easy configuration of the capitalisation of the letter, as well as two tests.